### PR TITLE
Feito mock para o UserNotTakenValidatorService

### DIFF
--- a/src/app/home/signup/signup.component.spec.ts
+++ b/src/app/home/signup/signup.component.spec.ts
@@ -1,5 +1,5 @@
 import { RouterTestingModule } from '@angular/router/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { AbstractControl, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { waitForAsync, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
@@ -14,6 +14,18 @@ describe('O formulário SignUp', () => {
     let component: SignUpComponent
     let router: Router
     let signupService: SignUpService
+
+    // TODO: Testar
+    class MockUserNotTakenValidatorService {
+        // Sempre que eu retorno null, o FormGroup entende que o campo esta válido
+        // Se eu retornar qualquer objeto (independente de seus valores), o FormGropu entende que o campo esta inválido
+        checkUserNameTaken() {
+            return (control: AbstractControl) => {
+                console.log(`Mock: ${control.value}`)
+                return of(null);
+            }
+        }
+    }
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
@@ -32,6 +44,12 @@ describe('O formulário SignUp', () => {
     }))
 
     beforeEach(() => {
+        // TODO: Testar
+        // Necessário, pois este provider foi enviado direto para o @Component do objeto de teste
+        TestBed.overrideProvider(UserNotTakenValidatorService, {
+            useValue: new MockUserNotTakenValidatorService()
+        })
+        
         router = TestBed.inject(Router)
         signupService = TestBed.inject(SignUpService)
 


### PR DESCRIPTION
Olá Henrique, muito prazer.

Eu vi o seu post no fórum da alura (https://cursos.alura.com.br/forum/topico-testes-nao-estao-passando-136971) e vi que você estava tendo o mesmo problema que eu.

Consegui descobrir o problema, quando você roda o teste do SignUpComponent, o TestBed não consegue simular o comportamento do UserNotTakenValidatorService, logo sempre dá o campo fullName inválido no formulário. E como essa classe é injetada direto pelo @Compoment do SignUpComponent, é preciso sobre-escrever os providers do TestBed.

Em resumo, tudo o que precisava ser feito, era criar uma mock para essa validador (MockUserNotTakenValidatorService) e passá-lo para a sobre-escrita do TestBed (por meio do comando TestBed.overrideProvider). Tenta dar uma testada na sua máquina para ver se roda, aqui eu tive que ajustar algumas coisas por causa do meu Linux e do Firefox. Espero que eu tenha conseguido explicar kkkkk.

Qualquer coisa, manda uma mensagem no LinkedIn (/matheushalmeida) ou pela Alura (não sei se é possível).

Att,
Matheus